### PR TITLE
Add `Dockerfile` and setup simple GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: "CCF App Template CI"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/ccf/app/dev:lts-devcontainer
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build App
+        run: mkdir -p build && cd build && CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja .. && ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  checks:
+  build-app:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/ccf/app/dev:lts-devcontainer
 
@@ -15,5 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Build App
+      - name: Build app
         run: mkdir -p build && cd build && CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja .. && ninja
+
+      - name: Build container
+        run: docker build -t ccf-app-template .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: mcr.microsoft.com/ccf/app/dev:lts-devcontainer
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build
+FROM mcr.microsoft.com/ccf/app/dev:2.0.7-sgx as builder
+COPY . /src
+RUN mkdir -p /build/
+WORKDIR /build/
+RUN CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja /src && ninja
+
+# Run
+FROM mcr.microsoft.com/ccf/app/run:2.0.7-sgx
+
+COPY --from=builder /build/libccf_app.enclave.so.signed /app/
+COPY --from=builder /opt/ccf/bin/*.js /app/
+COPY --from=builder /opt/ccf/bin/keygenerator.sh /app/ 
+COPY ./config/cchost_config.json /app/
+WORKDIR /app/
+RUN /app/keygenerator.sh --name member0 --gen-enc-key
+
+EXPOSE 8080/tcp
+
+CMD ["/usr/bin/cchost", "--config", "/app/cchost_config.json"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CCF C++ App Template
 
+[![CCF App Template CI](https://github.com/microsoft/ccf-app-template/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/ccf-app-template/actions/workflows/ci.yml)
+
 Template repository for CCF C++ applications.
 
 ## Install Dependencies

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Alternatively, it is possible to build a runtime image of this application via d
 $ docker build -t ccf-app-template .
 $ docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-template
 ...
-2022-09-02T10:19:21.433822Z -0.004 0   [info ] ../src/node/node_state.h:1790        | Network TLS connections now accepted
-# It is then possible to query the service externally
+2022-01-01T12:00:00.000000Z -0.000 0   [info ] ../src/node/node_state.h:1790        | Network TLS connections now accepted
+# It is then possible to interact with the service
 ```
 
 ## Code Tour

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ $ curl https://127.0.0.1:8000/app/log?id=1 --cacert ./workspace/sandbox_common/s
 "hello world"
 ```
 
+## Docker
+
+Alternatively, it is possible to build a runtime image of this application via docker:
+
+```bash
+$ docker build -t ccf-app-template .
+$ docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision -v /dev/sgx:/dev/sgx ccf-app-template
+...
+2022-09-02T10:19:21.433822Z -0.004 0   [info ] ../src/node/node_state.h:1790        | Network TLS connections now accepted
+# It is then possible to query the service externally
+```
+
 ## Code Tour
 
 To get a guided tour of the sample application, checkout this repository in VSCode and use the [CodeTour extension](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour).

--- a/config/cchost_config.json
+++ b/config/cchost_config.json
@@ -1,0 +1,32 @@
+{
+  "enclave": {
+    "file": "/app/libccf_app.enclave.so.signed",
+    "type": "Release"
+  },
+  "network": {
+    "node_to_node_interface": { "bind_address": "127.0.0.1:8081" },
+    "rpc_interfaces": {
+      "main_interface": {
+        "bind_address": "0.0.0.0:8080"
+      }
+    }
+  },
+  "command": {
+    "type": "Start",
+    "service_certificate_file": "/app/service_cert.pem",
+    "start": {
+      "constitution_files": [
+        "/app/validate.js",
+        "/app/apply.js",
+        "/app/resolve.js",
+        "/app/actions.js"
+      ],
+      "members": [
+        {
+          "certificate_file": "/app/member0_cert.pem",
+          "encryption_public_key_file": "/app/member0_enc_pubk.pem"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `Dockerfile` to build a minimal runtime image to run the template app, as well as a simple GitHub Actions CI. 