### PR TITLE
Change ./js/ into a Node.js project

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Development Container for CCF C++ Apps",
   "context": "..",
-  "image": "mcr.microsoft.com/ccf/app/dev:lts-devcontainer",
+  "build": { "dockerfile": "Dockerfile" },
   "runArgs": [],
   "extensions": [
     "ms-vscode.cpptools",

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/build/**
 *.deb
-/.venv_ccf_sandbox/
+**/.venv_ccf_sandbox/
 **/workspace/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/ccf/app/dev:lts-devcontainer
+
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && sudo apt-get install -y nodejs

--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ The JavaScript sample bundle is located in the [`js/`](js/) directory.
 ### Run JS app
 
 ```bash
-$ /opt/ccf/bin/sandbox.sh --js-app-bundle ./js/
+$ npm --prefix ./js install
+$ npm --prefix ./js run build
+$ /opt/ccf/bin/sandbox.sh --js-app-bundle ./js/dist/
 [12:00:00.000] Virtual mode enabled
 [12:00:00.000] Starting 1 CCF node...
 [12:00:00.000] Started CCF network with the following nodes:
 [12:00:00.000]   Node [0] = https://127.0.0.1:8000
 [12:00:00.000] You can now issue business transactions to the libjs_generic application
-[12:00:00.000] Loaded JS application: ./js/
-[12:00:00.000] Keys and certificates have been copied to the common folder: .../ccf-app-template/workspace/sandbox_common
+[12:00:00.000] Loaded JS application: ./js/dist/
+[12:00:00.000] Keys and certificates have been copied to the common folder: /workspaces/ccf-app-template/workspace/sandbox_common
 [12:00:00.000] See https://microsoft.github.io/CCF/main/use_apps/issue_commands.html for more information
 [12:00:00.000] Press Ctrl+C to shutdown the network
 ```

--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+node_modules/
+dist/

--- a/js/.npmrc
+++ b/js/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/js/build_bundle.js
+++ b/js/build_bundle.js
@@ -1,0 +1,53 @@
+import { readdirSync, statSync, readFileSync, writeFileSync } from "fs";
+import { join, posix, sep } from "path";
+
+const args = process.argv.slice(2);
+
+const getAllFiles = function (dirPath, arrayOfFiles) {
+  arrayOfFiles = arrayOfFiles || [];
+
+  const files = readdirSync(dirPath);
+  for (const file of files) {
+    const filePath = join(dirPath, file);
+    if (statSync(filePath).isDirectory()) {
+      arrayOfFiles = getAllFiles(filePath, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(filePath);
+    }
+  }
+
+  return arrayOfFiles;
+};
+
+const removePrefix = function (s, prefix) {
+  return s.substr(prefix.length).split(sep).join(posix.sep);
+};
+
+const rootDir = args[0];
+
+const metadataPath = join(rootDir, "app.json");
+const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
+
+const srcDir = join(rootDir, "src");
+const allFiles = getAllFiles(srcDir);
+
+// The trailing / is included so that it is trimmed in removePrefix.
+// This produces "foo/bar.js" rather than "/foo/bar.js"
+const toTrim = srcDir + "/";
+
+const modules = allFiles.map(function (filePath) {
+  return {
+    name: removePrefix(filePath, toTrim),
+    module: readFileSync(filePath, "utf-8"),
+  };
+});
+
+const bundlePath = join(args[0], "bundle.json");
+const bundle = {
+  metadata: metadata,
+  modules: modules,
+};
+console.log(
+  `Writing bundle containing ${modules.length} modules to ${bundlePath}`
+);
+writeFileSync(bundlePath, JSON.stringify(bundle));

--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@microsoft/ccf-app": "file:../../js/ccf-app",
+    "@microsoft/ccf-app": "^3.0.0-dev4",
     "js-base64": "^3.5.2",
     "jsrsasign": "^10.0.4",
     "jsrsasign-util": "^1.0.2",

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,28 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "del-cli -f dist/ && rollup --config && cp app.json dist/ && node build_bundle.js dist/",
+    "bundle": "node build_bundle.js dist",
+    "test": "node --version"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {
+    "@microsoft/ccf-app": "file:../../js/ccf-app",
+    "js-base64": "^3.5.2",
+    "jsrsasign": "^10.0.4",
+    "jsrsasign-util": "^1.0.2",
+    "jwt-decode": "^3.0.0",
+    "lodash-es": "^4.17.15",
+    "protobufjs": "^6.10.1"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^17.1.0",
+    "@rollup/plugin-node-resolve": "^11.2.0",
+    "del-cli": "^3.0.1",
+    "http-server": "^0.13.0",
+    "rollup": "^2.41.0"
+  }
+}

--- a/js/package.json
+++ b/js/package.json
@@ -10,19 +10,12 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@microsoft/ccf-app": "^3.0.0-dev4",
-    "js-base64": "^3.5.2",
-    "jsrsasign": "^10.0.4",
-    "jsrsasign-util": "^1.0.2",
-    "jwt-decode": "^3.0.0",
-    "lodash-es": "^4.17.15",
-    "protobufjs": "^6.10.1"
+    "@microsoft/ccf-app": "^3.0.0-dev4"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "del-cli": "^3.0.1",
-    "http-server": "^0.13.0",
     "rollup": "^2.41.0"
   }
 }

--- a/js/rollup.config.js
+++ b/js/rollup.config.js
@@ -1,0 +1,13 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+
+export default {
+  input: "src/app.js",
+  output: {
+    dir: "dist/src",
+    format: "es",
+    preserveModules: true,
+    preserveModulesRoot: "src",
+  },
+  plugins: [nodeResolve(), commonjs()],
+};

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -1,3 +1,5 @@
+import { ccf } from "@microsoft/ccf-app/global";
+
 function parse_request_query(request) {
   const elements = request.query.split("&");
   const obj = {};


### PR DESCRIPTION
## Change
This PR makes it easier to create practical JS applications.

## Test
- Open the development container in vscode. https://code.visualstudio.com/docs/remote/create-dev-container
  1. Open vscode
  2. Ctrl + Shift + P -> Run "Dev Containers: Clone Repository in Container Volume", and then input https://github.com/takuro-sato/ccf-app-template/tree/node_project (NOT main BRANCH). Maybe "Dev Containers: Clone GitHub Pull Request in Container Volume..." works as well.

  **You need to follow this way since the devcontainer was edited.**
- Follow "Run JS app" in README.md and see if the app works as before.