### PR TITLE
Add docker-from-docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,10 @@
   "extensions": [
     "ms-vscode.cpptools",
     "vsls-contrib.codetour"
-  ]
+  ],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-from-docker:1": {
+      "version": "20.10.8"
+    }
+  }
 }


### PR DESCRIPTION
Closes #13 

This PR adds Docker-from-docker support so that you can use your WSL host's docker daemon to build and run docker images from within the devcontainer.