### PR TITLE
Use an image that can use virtual

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/ccf/app/dev:lts-devcontainer
+FROM mcr.microsoft.com/ccf/app/dev:3.0.0-dev6-sgx
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && sudo apt-get install -y nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-cpp-app:
     runs-on: ubuntu-20.04
-    container: mcr.microsoft.com/ccf/app/dev:lts-devcontainer
+    container: mcr.microsoft.com/ccf/app/dev:3.0.0-dev6-sgx
 
     steps:
       - name: Checkout repository
@@ -21,7 +21,7 @@ jobs:
 
   build-containers:
     runs-on: ubuntu-20.04
-    container: mcr.microsoft.com/ccf/app/dev:lts-devcontainer
+    container: mcr.microsoft.com/ccf/app/dev:3.0.0-dev6-sgx
 
     steps:
       - name: Checkout repository

--- a/js/package.json
+++ b/js/package.json
@@ -10,7 +10,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@microsoft/ccf-app": "^3.0.0-dev4"
+    "@microsoft/ccf-app": "^3.0.0-dev6"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
Stop using `lts-devcontainer` since it now only supports sgx machine and also may be deprecated in future.
