### PR TITLE
Codespaces no longer requires org support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The quickest way to build and run this sample CCF app is to checkout this reposi
 
 All dependencies will be automatically installed (takes ~2 mins on first checkout).
 
-Alternatively, if your organisation supports it, you can checkout this repository in a Github codespace: [![Open in Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
+Alternatively, you can checkout this repository in a Github codespace: [![Open in Github codespace](https://img.shields.io/static/v1?label=Open+in&message=GitHub+codespace&logo=github&color=2F363D&logoColor=white&labelColor=2C2C32)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=496290904&machine=basicLinux32gb&devcontainer_path=.devcontainer.json&location=WestEurope)
 
 ## <img src="https://user-images.githubusercontent.com/42961061/191275583-88e00f94-73aa-4d66-9786-047987eb9fa9.png" height=50px> </img> JavaScript
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-11-09-codespaces-for-free-and-pro-accounts/