### PR TITLE
Update virtual docker build sample

### DIFF
--- a/docker/ccf_app_cpp.enclave
+++ b/docker/ccf_app_cpp.enclave
@@ -13,6 +13,10 @@ COPY --from=builder /opt/ccf_sgx/bin/*.js /app/
 COPY --from=builder /opt/ccf_sgx/bin/keygenerator.sh /app/ 
 COPY ./config/cchost_config_enclave_cpp.json /app/
 WORKDIR /app/
+# IMPORTANT: This creates a member key pair and stores it in the container,
+# which is only acceptable for test purposes. A real deployment must instead
+# create and store keys somewhere secure, and only load the public key in the
+# container, preferably through a mount.
 RUN /app/keygenerator.sh --name member0 --gen-enc-key
 
 EXPOSE 8080/tcp

--- a/docker/ccf_app_cpp.virtual
+++ b/docker/ccf_app_cpp.virtual
@@ -13,6 +13,10 @@ COPY --from=builder /opt/ccf_virtual/bin/*.js /app/
 COPY --from=builder /opt/ccf_virtual/bin/keygenerator.sh /app/ 
 COPY ./config/cchost_config_virtual_cpp.json /app/
 WORKDIR /app/
+# IMPORTANT: This creates a member key pair and stores it in the container,
+# which is only acceptable for test purposes. A real deployment must instead
+# create and store keys somewhere secure, and only load the public key in the
+# container, preferably through a mount.
 RUN /app/keygenerator.sh --name member0 --gen-enc-key
 
 EXPOSE 8080/tcp

--- a/docker/ccf_app_js.enclave
+++ b/docker/ccf_app_js.enclave
@@ -8,6 +8,10 @@ COPY --from=builder /opt/ccf_sgx/bin/*.js /app/
 COPY --from=builder /opt/ccf_sgx/bin/keygenerator.sh /app/ 
 COPY ./config/cchost_config_enclave_js.json /app/
 WORKDIR /app/
+# IMPORTANT: This creates a member key pair and stores it in the container,
+# which is only acceptable for test purposes. A real deployment must instead
+# create and store keys somewhere secure, and only load the public key in the
+# container, preferably through a mount.
 RUN /app/keygenerator.sh --name member0 --gen-enc-key
 
 EXPOSE 8080/tcp

--- a/docker/ccf_app_js.virtual
+++ b/docker/ccf_app_js.virtual
@@ -4,14 +4,14 @@ FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.0 as builder
 # Run
 FROM ghcr.io/microsoft/ccf/app/run-js/virtual:ccf-5.0.0
 
-# Note: libjs_generic.virtual is not included in run-js container
-COPY --from=builder /opt/ccf_virtual/lib/libjs_generic.virtual.so /usr/lib/ccf
-RUN true # https://github.com/moby/moby/issues/37965
 COPY --from=builder /opt/ccf_virtual/bin/*.js /app/
-RUN true # https://github.com/moby/moby/issues/37965
 COPY --from=builder /opt/ccf_virtual/bin/keygenerator.sh /app/ 
 COPY ./config/cchost_config_virtual_js.json /app/
 WORKDIR /app/
+# IMPORTANT: This creates a member key pair and stores it in the container,
+# which is only acceptable for test purposes. A real deployment must instead
+# create and store keys somewhere secure, and only load the public key in the
+# container, preferably through a mount.
 RUN /app/keygenerator.sh --name member0 --gen-enc-key
 
 EXPOSE 8080/tcp


### PR DESCRIPTION
Update all build files to add warning about key creation, and remove now-unnecessary library copy from the run-js virtual container.