### PR TITLE
Fix package.json and bump Nodejs LTS version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.0
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && sudo apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
         run: mkdir -p build && cd build && CC="$(which clang-15)" CXX="$(which clang++-15)" cmake -GNinja -DCOMPILE_TARGET=virtual .. && ninja
         working-directory: cpp
 
+  build-js-app:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Build js app
+        run: npm install && npm run build
+        working-directory: js
+
   build-containers:
     runs-on: ubuntu-20.04
     container: ghcr.io/microsoft/ccf/app/dev/sgx:ccf-5.0.0

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",
-    "@rollup/plugin-node-resolve": "^15.2
+    "@rollup/plugin-node-resolve": "^15.2",
     "@rollup/plugin-typescript": "^11.1.6",
     "del-cli": "^5.1.0",
     "rollup": "^2.41.0",


### PR DESCRIPTION
- Fixed `package.json` containing a syntax error
- Updated devcontainer Nodejs version to v18 as v16 is outdated
- Additional task in GitHub actions added to make sure that js app can be built